### PR TITLE
Fix possible Build-Dependencies connection error

### DIFF
--- a/eng/Build-Dependencies.ps1
+++ b/eng/Build-Dependencies.ps1
@@ -144,6 +144,7 @@ $nuget = Get-Command nuget -ErrorAction SilentlyContinue
 if (! $nuget) {
     Write-Output 'Downloading nuget commandline client'
     $nuget = Join-Path (Join-Path $rootDir 'build') 'nuget.exe'
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     Invoke-WebRequest -Uri https://dist.nuget.org/win-x86-commandline/v5.4.0/nuget.exe -OutFile $nuget
 }
 
@@ -152,3 +153,5 @@ Step -N 5 -Status 'Installing Nuget package to solution' -Failure 'nuget install
     &$nuget install $nugetPackageId -Version $nugetPackageVersion -Source $VcpkgDir `
             -OutputDirectory $packagesDir -NonInteractive -Verbosity quiet
 }
+
+Write-Output 'Installation successful.'


### PR DESCRIPTION
The connection security protocol may need to be set
in order for the web request to succeed when
downloading the nuget CLI application.

Also adds a final message once the script succeeds, since without looking while it's running there's no clear indication of success or failure.