### PR TITLE
Fix the vcpkg revision in Build-Dependencies

### DIFF
--- a/eng/Build-Dependencies.ps1
+++ b/eng/Build-Dependencies.ps1
@@ -24,7 +24,7 @@ if (! $VcpkgRepository) {
 }
 
 if (! $VcpkgRevision) {
-    $VcpkgRevision = 'ba75631be7ea8ada210da3aa83f0f95c4f478a08'
+    $VcpkgRevision = '2020.11-1'
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
The default revision did not exist and caused
the script to fail on a first run.